### PR TITLE
Removing tokbox maven url

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,8 +52,6 @@ allprojects {
     maven {
       url 'https://s3.amazonaws.com/salesforcesos.com/android/maven/release'
     }
-    maven {
-      url 'http://tokbox.bintray.com/maven/'
-    }
+    mavenCentral()
   }
 }


### PR DESCRIPTION
Trying to remove dependency on the tokbox maven url.

The tokbox maven location regularly fails to resolve. See error below: 
```* What went wrong:
Execution failed for task ':react-native-salesforce-chat:mergeReleaseResources'.
> Could not resolve all files for configuration ':react-native-salesforce-chat:releaseRuntimeClasspath'.
   > Could not resolve com.facebook.react:react-native:+.
     Required by:
         project :react-native-salesforce-chat
      > Failed to list versions for com.facebook.react:react-native.
         > Unable to load Maven meta-data from https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml.
            > Could not get resource 'https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml'.
               > Could not GET 'https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml'.
                  > salesforcesos.com: nodename nor servname provided, or not known
      > Failed to list versions for com.facebook.react:react-native.
         > Unable to load Maven meta-data from http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml.
            > Could not get resource 'http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml'.
               > Could not GET 'http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml'. Received status code 502 from server: Bad Gateway
```